### PR TITLE
Better handling of other loginwrapperchannel (FML2, FML3)

### DIFF
--- a/src/client/data/fml3.json
+++ b/src/client/data/fml3.json
@@ -133,7 +133,6 @@
                 "4": "ConfigurationData",
                 "5": "ModData",
                 "6": "ChannelMismatchData",
-                "98": "Quark",
                 "99": "Acknowledgement"
               }
             }
@@ -373,7 +372,6 @@
                     }
                   ]
                 ],
-                "Quark": "void",
                 "Acknowledgement": "void"
               }
             }

--- a/src/client/forgeHandshake2.js
+++ b/src/client/forgeHandshake2.js
@@ -217,9 +217,8 @@ module.exports = function (client, options) {
         }
 
         default:
-          console.log('other loginwrapperchannel', loginwrapper.channel, 'received')
           try {
-            console.log('attempting to send acknowledgement packet to', loginwrapper.channel, 'loginwrapperchannel')
+            console.log('other loginwrapperchannel', loginwrapper.channel, 'received, sending acknowledgement packet')
             const AcknowledgementPacket = proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, { discriminator: 'Acknowledgement' })
             const loginWrapperPacket = proto.createPacketBuffer(PROTODEF_TYPES.LOGINWRAPPER, { channel: FML_CHANNELS.HANDSHAKE, data: AcknowledgementPacket })
             client.write('login_plugin_response', { messageId: data.messageId, data: loginWrapperPacket })

--- a/src/client/forgeHandshake2.js
+++ b/src/client/forgeHandshake2.js
@@ -217,23 +217,15 @@ module.exports = function (client, options) {
         }
 
         default:
-          console.log(
-              'other loginwrapperchannel',
-              loginwrapper.channel,
-              'received'
-          )
+          console.log('other loginwrapperchannel', loginwrapper.channel, 'received')
           try {
-            console.log(
-                'attempting to acknowledge',
-                loginwrapper.channel,
-                'loginwrapperchannel'
-            )
-            let AcknowledgementPacket = proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, { discriminator: "Acknowledgement" });
-            let loginWrapperPacket = proto.createPacketBuffer(PROTODEF_TYPES.LOGINWRAPPER, { channel: FML_CHANNELS.HANDSHAKE, data: AcknowledgementPacket, });
-            client.write("login_plugin_response", { messageId: data.messageId, data: loginWrapperPacket });
+            console.log('attempting to acknowledge', loginwrapper.channel, 'loginwrapperchannel')
+            const AcknowledgementPacket = proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, { discriminator: 'Acknowledgement' })
+            const loginWrapperPacket = proto.createPacketBuffer(PROTODEF_TYPES.LOGINWRAPPER, { channel: FML_CHANNELS.HANDSHAKE, data: AcknowledgementPacket })
+            client.write('login_plugin_response', { messageId: data.messageId, data: loginWrapperPacket })
             break
           } catch (error) {
-            console.error(error);
+            console.error(error)
           }
           break
       }

--- a/src/client/forgeHandshake2.js
+++ b/src/client/forgeHandshake2.js
@@ -219,7 +219,7 @@ module.exports = function (client, options) {
         default:
           console.log('other loginwrapperchannel', loginwrapper.channel, 'received')
           try {
-            console.log('attempting to acknowledge', loginwrapper.channel, 'loginwrapperchannel')
+            console.log('attempting to send acknowledgement packet to', loginwrapper.channel, 'loginwrapperchannel')
             const AcknowledgementPacket = proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, { discriminator: 'Acknowledgement' })
             const loginWrapperPacket = proto.createPacketBuffer(PROTODEF_TYPES.LOGINWRAPPER, { channel: FML_CHANNELS.HANDSHAKE, data: AcknowledgementPacket })
             client.write('login_plugin_response', { messageId: data.messageId, data: loginWrapperPacket })

--- a/src/client/forgeHandshake2.js
+++ b/src/client/forgeHandshake2.js
@@ -218,10 +218,23 @@ module.exports = function (client, options) {
 
         default:
           console.log(
-            'other loginwrapperchannel',
-            loginwrapper.channel,
-            'received'
+              'other loginwrapperchannel',
+              loginwrapper.channel,
+              'received'
           )
+          try {
+            console.log(
+                'attempting to acknowledge',
+                loginwrapper.channel,
+                'loginwrapperchannel'
+            )
+            let AcknowledgementPacket = proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, { discriminator: "Acknowledgement" });
+            let loginWrapperPacket = proto.createPacketBuffer(PROTODEF_TYPES.LOGINWRAPPER, { channel: FML_CHANNELS.HANDSHAKE, data: AcknowledgementPacket, });
+            client.write("login_plugin_response", { messageId: data.messageId, data: loginWrapperPacket });
+            break
+          } catch (error) {
+            console.error(error);
+          }
           break
       }
     } else {

--- a/src/client/forgeHandshake3.js
+++ b/src/client/forgeHandshake3.js
@@ -246,37 +246,6 @@ module.exports = function (client, options) {
           break
         }
 
-        case 'quark:main': {
-          const { data: quarkHandshake } = proto.parsePacketBuffer(
-            PROTODEF_TYPES.HANDSHAKE,
-            loginwrapper.data
-          )
-
-          let quarkLoginwrapperpacket = Buffer.alloc(0)
-          switch (quarkHandshake.discriminator) {
-            // respond with Ack
-            case 'Quark': {
-              quarkLoginwrapperpacket = proto.createPacketBuffer(
-                PROTODEF_TYPES.LOGINWRAPPER,
-                {
-                  channel: FML_CHANNELS.HANDSHAKE,
-                  data: proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, {
-                    discriminator: 'Acknowledgement',
-                    data: {}
-                  })
-                }
-              )
-              break
-            }
-          }
-
-          client.write('login_plugin_response', {
-            messageId: data.messageId,
-            data: quarkLoginwrapperpacket
-          })
-          break
-        }
-
         default:
           console.log('other loginwrapperchannel', loginwrapper.channel, 'received')
           try {

--- a/src/client/forgeHandshake3.js
+++ b/src/client/forgeHandshake3.js
@@ -278,23 +278,15 @@ module.exports = function (client, options) {
         }
 
         default:
-          console.log(
-              'other loginwrapperchannel',
-              loginwrapper.channel,
-              'received'
-          )
+          console.log('other loginwrapperchannel', loginwrapper.channel, 'received')
           try {
-            console.log(
-                'attempting to acknowledge',
-                loginwrapper.channel,
-                'loginwrapperchannel'
-            )
-            let AcknowledgementPacket = proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, { discriminator: "Acknowledgement" });
-            let loginWrapperPacket = proto.createPacketBuffer(PROTODEF_TYPES.LOGINWRAPPER, { channel: FML_CHANNELS.HANDSHAKE, data: AcknowledgementPacket, });
-            client.write("login_plugin_response", { messageId: data.messageId, data: loginWrapperPacket });
+            console.log('attempting to acknowledge', loginwrapper.channel, 'loginwrapperchannel')
+            const AcknowledgementPacket = proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, { discriminator: 'Acknowledgement' })
+            const loginWrapperPacket = proto.createPacketBuffer(PROTODEF_TYPES.LOGINWRAPPER, { channel: FML_CHANNELS.HANDSHAKE, data: AcknowledgementPacket })
+            client.write('login_plugin_response', { messageId: data.messageId, data: loginWrapperPacket })
             break
           } catch (error) {
-            console.error(error);
+            console.error(error)
           }
           break
       }

--- a/src/client/forgeHandshake3.js
+++ b/src/client/forgeHandshake3.js
@@ -279,10 +279,23 @@ module.exports = function (client, options) {
 
         default:
           console.log(
-            'other loginwrapperchannel',
-            loginwrapper.channel,
-            'received'
+              'other loginwrapperchannel',
+              loginwrapper.channel,
+              'received'
           )
+          try {
+            console.log(
+                'attempting to acknowledge',
+                loginwrapper.channel,
+                'loginwrapperchannel'
+            )
+            let AcknowledgementPacket = proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, { discriminator: "Acknowledgement" });
+            let loginWrapperPacket = proto.createPacketBuffer(PROTODEF_TYPES.LOGINWRAPPER, { channel: FML_CHANNELS.HANDSHAKE, data: AcknowledgementPacket, });
+            client.write("login_plugin_response", { messageId: data.messageId, data: loginWrapperPacket });
+            break
+          } catch (error) {
+            console.error(error);
+          }
           break
       }
     } else {

--- a/src/client/forgeHandshake3.js
+++ b/src/client/forgeHandshake3.js
@@ -247,9 +247,8 @@ module.exports = function (client, options) {
         }
 
         default:
-          console.log('other loginwrapperchannel', loginwrapper.channel, 'received')
           try {
-            console.log('attempting to send acknowledgement packet to', loginwrapper.channel, 'loginwrapperchannel')
+            console.log('other loginwrapperchannel', loginwrapper.channel, 'received, sending acknowledgement packet')
             const AcknowledgementPacket = proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, { discriminator: 'Acknowledgement' })
             const loginWrapperPacket = proto.createPacketBuffer(PROTODEF_TYPES.LOGINWRAPPER, { channel: FML_CHANNELS.HANDSHAKE, data: AcknowledgementPacket })
             client.write('login_plugin_response', { messageId: data.messageId, data: loginWrapperPacket })

--- a/src/client/forgeHandshake3.js
+++ b/src/client/forgeHandshake3.js
@@ -249,7 +249,7 @@ module.exports = function (client, options) {
         default:
           console.log('other loginwrapperchannel', loginwrapper.channel, 'received')
           try {
-            console.log('attempting to acknowledge', loginwrapper.channel, 'loginwrapperchannel')
+            console.log('attempting to send acknowledgement packet to', loginwrapper.channel, 'loginwrapperchannel')
             const AcknowledgementPacket = proto.createPacketBuffer(PROTODEF_TYPES.HANDSHAKE, { discriminator: 'Acknowledgement' })
             const loginWrapperPacket = proto.createPacketBuffer(PROTODEF_TYPES.LOGINWRAPPER, { channel: FML_CHANNELS.HANDSHAKE, data: AcknowledgementPacket })
             client.write('login_plugin_response', { messageId: data.messageId, data: loginWrapperPacket })


### PR DESCRIPTION
There are some errors upon login reported with the current implementation of FML2 & FML3 protocol. Examples: Quark mod (version 410+, FML3), MrCrayfish's Gun Mod (both FML2 & 3). These mods use custom handshakes.

The way to deal with it is to acknowledge any packet from other loginwrapperchannels (from mods). This is enough to login with mentioned mods, but I implement this in try...catch block should it ever lead to an exception in some other unknown cases. Acknowledgments to @LetsChill, to whose code I returned while implementing this change. 

Fixes https://github.com/PrismarineJS/node-minecraft-protocol-forge/issues/29